### PR TITLE
Your module is not easy_installable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.pyc
+*.egg-info
+*.pyc
+build

--- a/croniter/__init__.py
+++ b/croniter/__init__.py
@@ -1,45 +1,9 @@
 # -*- coding: utf-8 -*-
-
-"""
-    Simple example of usage is followings
-
-    >>> from croniter import croniter
-    >>> from datetime import datetime
-    >>> base = datetime(2010, 1, 25, 4, 46)
-    >>> iter = croniter('*/5 * * * *', base)  # every 5 minites
-    >>> print iter.get_next(datetime)   # 2010-01-25 04:50:00
-    >>> print iter.get_next(datetime)   # 2010-01-25 04:55:00
-    >>> print iter.get_next(datetime)   # 2010-01-25 05:00:00
-    >>>
-    >>> iter = croniter('2 4 * * mon,fri', base)  # 04:02 on every Monday and Friday
-    >>> print iter.get_next(datetime)   # 2010-01-26 04:02:00
-    >>> print iter.get_next(datetime)   # 2010-01-30 04:02:00
-    >>> print iter.get_next(datetime)   # 2010-02-02 04:02:00
-
-    All you need to know is constructor and get_next, these signature are following.
-
-    >>> def __init__(self, cron_format, start_time=time.time())
-    
-    croniter iterate along with 'cron_format' from 'start_time'.
-    cron_format is 'min hour day month day_of_week', and please refer to
-    http://en.wikipedia.org/wiki/Cron for details.
-
-    >>> def get_next(self, ret_type=float)
-    
-    get_next return next time in iteration with 'ret_type'.
-    And ret_type accept only 'float' or 'datetime'.
-
-    Now, supported get_prev method. (>= 0.2.0)
-    
-    >>> base = datetime(2010, 8, 25)
-    >>> itr = croniter('0 0 1 * *', base)
-    >>> print itr.get_prev(datetime)  # 2010-08-01 00:00:00
-    >>> print itr.get_prev(datetime)  # 2010-07-01 00:00:00
-    >>> print itr.get_prev(datetime)  # 2010-06-01 00:00:00
-"""
-
-__author__  = "Matsumoto Taichi"
-__version__ = "0.2.0"
-__license__ = "MIT License"
-
+# defer imports to be accesible in setup.py
+from _release import (
+    __doc__,
+    __author__,
+    __version__,
+    __license__,
+)
 from croniter import croniter

--- a/croniter/_release.py
+++ b/croniter/_release.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+__author__  = "Matsumoto Taichi"
+__version__ = "0.2.0"
+__license__ = "MIT License"
+__doc__ = """
+    Simple example of usage is followings
+
+    >>> from croniter import croniter
+    >>> from datetime import datetime
+    >>> base = datetime(2010, 1, 25, 4, 46)
+    >>> iter = croniter('*/5 * * * *', base)  # every 5 minites
+    >>> print iter.get_next(datetime)   # 2010-01-25 04:50:00
+    >>> print iter.get_next(datetime)   # 2010-01-25 04:55:00
+    >>> print iter.get_next(datetime)   # 2010-01-25 05:00:00
+    >>>
+    >>> iter = croniter('2 4 * * mon,fri', base)  # 04:02 on every Monday and Friday
+    >>> print iter.get_next(datetime)   # 2010-01-26 04:02:00
+    >>> print iter.get_next(datetime)   # 2010-01-30 04:02:00
+    >>> print iter.get_next(datetime)   # 2010-02-02 04:02:00
+
+    All you need to know is constructor and get_next, these signature are following.
+
+    >>> def __init__(self, cron_format, start_time=time.time())
+
+    croniter iterate along with 'cron_format' from 'start_time'.
+    cron_format is 'min hour day month day_of_week', and please refer to
+    http://en.wikipedia.org/wiki/Cron for details.
+
+    >>> def get_next(self, ret_type=float)
+
+    get_next return next time in iteration with 'ret_type'.
+    And ret_type accept only 'float' or 'datetime'.
+
+    Now, supported get_prev method. (>= 0.2.0)
+
+    >>> base = datetime(2010, 8, 25)
+    >>> itr = croniter('0 0 1 * *', base)
+    >>> print itr.get_prev(datetime)  # 2010-08-01 00:00:00
+    >>> print itr.get_prev(datetime)  # 2010-07-01 00:00:00
+    >>> print itr.get_prev(datetime)  # 2010-06-01 00:00:00
+"""
+# vim:set et sts=4 ts=4 tw=80:

--- a/setup.py
+++ b/setup.py
@@ -1,35 +1,20 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup
-import sys
-import unittest
-
-import croniter
-from croniter import __version__, __license__, __author__
-
-if __name__ == '__main__':
-  from croniter import croniter_test
-  # run module test
-  loader = unittest.TestLoader()
-  result = unittest.TestResult()
-  suite  = loader.loadTestsFromModule(croniter_test)
-  suite.run(result)
-  if not result.wasSuccessful():
-    print "unit tests have failed!"
-    print "aborted to make a source distribution"
-    sys.exit(1)
-
-  # build distribution package
-  setup(
+__version__, __doc__, __license__, __author__ = None, None, None, None
+# get __version__, __doc__, __license__, __author__
+execfile("croniter/_release.py")
+setup(
     packages         = ('croniter',),
     name             = 'croniter',
     version          = __version__,
     py_modules       = ['croniter', 'croniter_test'],
     description      = 'croniter provides iteration for datetime object with cron like format',
-    long_description = croniter.__doc__,
+    long_description = __doc__,
     author           = __author__,
     author_email     = 'taichino@gmail.com',
     url              = 'http://github.com/taichino/croniter',
     keywords         = 'datetime, iterator, cron',
+    install_requires = ["python-dateutil", "setuptools",],
     license          = __license__,
     classifiers      = ["Development Status :: 3 - Alpha",
                         "Intended Audience :: Developers",
@@ -37,4 +22,4 @@ if __name__ == '__main__':
                         "Operating System :: POSIX",
                         "Programming Language :: Python",
                         "Topic :: Software Development :: Libraries :: Python Modules"]
-    )
+)


### PR DESCRIPTION
Hello, if you dont have python-dateutil system wide installed prior to the easy_install call, your module is undeployable.

With buildout and its isolation system, it's even more complicated !

The following changeset just make your package proper packaged, and is ready for a new release on pypi.
