### PR TITLE
Fix `get_prev()` when crossing into previous month

### DIFF
--- a/croniter/croniter.py
+++ b/croniter/croniter.py
@@ -15,6 +15,7 @@ __all__ = ('croniter',)
 
 
 class croniter(object):
+    MONTHS_IN_YEAR = 12
     RANGES = (
         (0, 59),
         (0, 23),
@@ -162,7 +163,7 @@ class croniter(object):
 
         def proc_month(d):
             if expanded[3][0] != '*':
-                diff_month = nearest_diff_method(month, expanded[3], 12)
+                diff_month = nearest_diff_method(month, expanded[3], self.MONTHS_IN_YEAR)
                 days = DAYS[month - 1]
                 if month == 2 and self.is_leap(year) == True:
                     days += 1
@@ -184,7 +185,11 @@ class croniter(object):
                 if month == 2 and self.is_leap(year) == True:
                     days += 1
 
-                diff_day = nearest_diff_method(d.day, expanded[2], days)
+                if is_prev:
+                    days_in_prev_month = DAYS[(month - 2) % self.MONTHS_IN_YEAR]
+                    diff_day = nearest_diff_method(d.day, expanded[2], days_in_prev_month)
+                else:
+                    diff_day = nearest_diff_method(d.day, expanded[2], days)
 
                 if diff_day != None and diff_day != 0:
                     if is_prev:

--- a/croniter/croniter_test.py
+++ b/croniter/croniter_test.py
@@ -155,6 +155,17 @@ class CroniterTest(unittest.TestCase):
     self.assertEqual(23, prev.hour)
     self.assertEqual(59, prev.minute)
 
+  def testPrevDayOfMonthWithCrossing(self):
+    """Test getting previous occurrence that crosses into previous month."""
+    base = datetime(2012, 3, 15, 0, 0)
+    itr = croniter('0 0 22 * *', base)
+    prev = itr.get_prev(datetime)
+    self.assertEqual(prev.year, 2012)
+    self.assertEqual(prev.month, 2)
+    self.assertEqual(prev.day, 22)
+    self.assertEqual(prev.hour, 0)
+    self.assertEqual(prev.minute, 0)
+
   def testPrevWeekDay(self):
     base = datetime(2010, 8, 25, 15, 56)
     itr = croniter('0 0 * * sat,sun', base)


### PR DESCRIPTION
Added the test `testPrevDayOfMonthWithCrossing` to document this bug.

The issue relates to this line of `_get_prev_nearest_diff()`:

```
return (candidates[0]) - x - range_val
```

When called from `proc_day_of_month()`, `range_val` should be the number of days
in the prevoius month, not the current month.
