### PR TITLE
Python 3 support

### DIFF
--- a/croniter/__init__.py
+++ b/croniter/__init__.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 # defer imports to be accesible in setup.py
-from _release import (
+
+from __future__ import absolute_import
+
+from ._release import (
     __doc__,
     __author__,
     __version__,
     __license__,
 )
-from croniter import croniter
+from .croniter import croniter

--- a/croniter/croniter.py
+++ b/croniter/croniter.py
@@ -1,6 +1,7 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import, print_function
 import re
 from time import time, mktime
 import datetime
@@ -86,7 +87,7 @@ class croniter(object):
                         or not only_int_re.search(str(step))):
                         raise ValueError("[%s] is not acceptable" %expr_format)
 
-                    for j in xrange(int(low), int(high)+1):
+                    for j in range(int(low), int(high)+1):
                         if j % int(step) == 0:
                             e_list.append(j)
                 else:
@@ -315,4 +316,4 @@ if __name__ == '__main__':
     base = datetime.datetime(2010, 1, 25)
     itr = croniter('0 0 1 * *', base)
     n1 = itr.get_next(datetime.datetime)
-    print n1
+    print(n1)

--- a/croniter/croniter_test.py
+++ b/croniter/croniter_test.py
@@ -1,6 +1,7 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
 import unittest
 from datetime import datetime
 from croniter import croniter
@@ -227,7 +228,7 @@ class CroniterTest(unittest.TestCase):
     self.assertEqual(n1.minute, 5)
 
   def testBug2(self):
-    base = datetime(2012, 01, 01, 00, 00)
+    base = datetime(2012, 1, 1, 0, 0)
     iter = croniter('0 * * 3 *', base)
     n1 = iter.get_next(datetime)
     self.assertEqual(n1.year, base.year)

--- a/croniter/speed_test.py
+++ b/croniter/speed_test.py
@@ -1,8 +1,8 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import time
-from datetime import datetime, date
+from __future__ import absolute_import, print_function
+from datetime import datetime
 from croniter import croniter
 
 class timerTest(object):
@@ -210,4 +210,4 @@ class CroniterTest(timerTest):
 if __name__ == '__main__':
     from timeit import Timer
     t = Timer('c=CroniterTest();c.run()', 'from __main__ import CroniterTest')
-    print t.timeit(200)
+    print(t.timeit(200))

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup
+
 __version__, __doc__, __license__, __author__ = None, None, None, None
 # get __version__, __doc__, __license__, __author__
-execfile("croniter/_release.py")
+
+exec(open("croniter/_release.py").read())
+
 setup(
     packages         = ('croniter',),
     name             = 'croniter',


### PR DESCRIPTION
Converted everything to run on Python 2 and Python 3. Mainly print statements and relative vs absolute imports. Tested on versions 2.7 and 3.2.
