### PR TITLE
Breaking crontab specification for ranges

### DIFF
--- a/croniter/croniter.py
+++ b/croniter/croniter.py
@@ -86,9 +86,8 @@ class croniter(object):
                         or not only_int_re.search(str(step))):
                         raise ValueError("[%s] is not acceptable" %expr_format)
 
-                    for j in xrange(int(low), int(high)+1):
-                        if j % int(step) == 0:
-                            e_list.append(j)
+                    for j in xrange(int(low), int(high)+1, int(step)):
+                        e_list.append(j)
                 else:
                     if not star_or_int_re.search(t):
                         t = self.ALPHACONV[i][t.lower()]


### PR DESCRIPTION
The specification listed in crontab(5) man page states:

> A field may be an asterisk (*), which always stands for ``first-last''.
> ...
> Ranges can include "steps", so "1-9/2" is the same as "1,3,5,7,9".

The current version has 1-9/2 generate 2,4,6,8, when it should generate the list stated above.
The current version has 4-13/3 generate 6,9,12, when it should generate 4,7,10,13.

The fix removed the mod method and replace it with a step in xrange.
