### PR TITLE
Removing unnecessary setuptools depedency 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     author_email     = 'taichino@gmail.com',
     url              = 'http://github.com/taichino/croniter',
     keywords         = 'datetime, iterator, cron',
-    install_requires = ["python-dateutil", "setuptools",],
+    install_requires = ["python-dateutil"],
     license          = __license__,
     classifiers      = ["Development Status :: 4 - Beta",
                         "Intended Audience :: Developers",


### PR DESCRIPTION
This dependency cause setuptools to be corrupted by latest distribute update which will break pip/easyinstall after that 
