### PR TITLE
removed croniter dependancy on the setuptools package in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
     keywords='datetime, iterator, cron',
     install_requires=[
         "python-dateutil",
-        "setuptools",
     ],
     license="MIT License",
     classifiers=[


### PR DESCRIPTION
in setup.py, install_requires contains setuptools. This is unnecessary and can cause problems under certain specific conditions. 

First, I believe it is unnecessary because in the imports section at the very top of setup.py, setuptools is already referenced. Therefore this would not even run if setuptools was not already installs.

Second, the problem. I am attempting to install in an alternate location without root permissions on linux. I have passed all the available flags to specify the alternate location and also to ignore if already installed on the box. The problem is having setuptools as a install_requires will attempt to replace easy_install which is located in /usr/bin and owned by root. 

I don't believe that this is the intention of using install_requires for setuptools and since it is already required to run python setup.py install, it's unnecessary. 

thanks
