### PR TITLE
Fix default behavior when no start_time given

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -52,7 +52,10 @@ class croniter(object):
     bad_length = 'Exactly 5 or 6 columns has to be specified for iterator' \
                  'expression.'
 
-    def __init__(self, expr_format, start_time=time()):
+    def __init__(self, expr_format, start_time=None):
+        if start_time is None:
+            start_time = time()
+
         self.tzinfo = None
         if isinstance(start_time, datetime.datetime):
             self.tzinfo = start_time.tzinfo

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -3,6 +3,7 @@
 
 import unittest
 from datetime import datetime
+from time import sleep
 import pytz
 from croniter import croniter
 
@@ -391,6 +392,12 @@ class CroniterTest(base.TestCase):
         itr2 = croniter('* * * * *', tokyo.localize(base))
         n2 = itr2.get_next(datetime)
         self.assertEqual(n2.tzinfo.zone, 'Asia/Tokyo')
+
+    def testInitNoStartTime(self):
+        itr = croniter('* * * * *')
+        sleep(.01)
+        itr2 = croniter('* * * * *')
+        self.assertGreater(itr2.cur, itr.cur)
 
     def assertScheduleTimezone(self, callback, expected_schedule):
         for expected_date, expected_offset in expected_schedule:


### PR DESCRIPTION
Default value for `start_time` parameter is calculated at module init time rather than call time.