### PR TITLE
Don't use datetime functions python 2.6 doesn't support

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -155,7 +155,7 @@ class croniter(object):
         if d.tzinfo is not None:
             d = d.replace(tzinfo=None) - d.utcoffset()
 
-        return (d - datetime.datetime(1970, 1, 1)).total_seconds()
+        return self._timedelta_to_seconds(d - datetime.datetime(1970, 1, 1))
 
     def _timestamp_to_datetime(self, timestamp):
         """
@@ -166,6 +166,15 @@ class croniter(object):
             result = result.replace(tzinfo=tzutc()).astimezone(self.tzinfo)
 
         return result
+
+    def _timedelta_to_seconds(self, td):
+        """
+        Converts a 'datetime.timedelta' object `td` into seconds contained in
+        the duration
+        """
+        return (td.microseconds + (td.seconds + td.days * 24 * 3600) * 10**6) \
+            / 10**6
+
 
     # iterator protocol, to enable direct use of croniter
     # objects in a loop, like "for dt in croniter('5 0 * * *'): ..."

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -167,7 +167,8 @@ class croniter(object):
 
         return result
 
-    def _timedelta_to_seconds(self, td):
+    @classmethod
+    def _timedelta_to_seconds(cls, td):
         """
         Converts a 'datetime.timedelta' object `td` into seconds contained in
         the duration

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -171,11 +171,12 @@ class croniter(object):
     def _timedelta_to_seconds(cls, td):
         """
         Converts a 'datetime.timedelta' object `td` into seconds contained in
-        the duration
+        the duration.
+        Note: We cannot use `timedelta.total_seconds()` because this is not
+        supported by Python 2.6.
         """
         return (td.microseconds + (td.seconds + td.days * 24 * 3600) * 10**6) \
             / 10**6
-
 
     # iterator protocol, to enable direct use of croniter
     # objects in a loop, like "for dt in croniter('5 0 * * *'): ..."

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -414,7 +414,7 @@ class CroniterTest(base.TestCase):
         for expected_date, expected_offset in expected_schedule:
             d = callback()
             self.assertEqual(expected_date, d.replace(tzinfo=None))
-            self.assertEqual(expected_offset, d.utcoffset().total_seconds())
+            self.assertEqual(expected_offset, croniter._timedelta_to_seconds(d.utcoffset()))
 
     def testTimezoneWinterTime(self):
         tz = pytz.timezone('Europe/Athens')


### PR DESCRIPTION
fixes #44
- created `_timedelta_to_seconds`-function because `datetime` (python 2.6) doesn't support `timedelta.total_seconds()`
- replaced all occurences of `timedelta.total_seconds()` with this created function