### PR TITLE
Compare types using `issubclass` instead of exact match

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -153,7 +153,7 @@ class croniter(object):
 
     def get_current(self, ret_type=None):
         ret_type = ret_type or self._ret_type
-        if ret_type == datetime.datetime:
+        if issubclass(ret_type,  datetime.datetime):
             return self._timestamp_to_datetime(self.cur)
         return self.cur
 
@@ -215,7 +215,7 @@ class croniter(object):
 
         ret_type = ret_type or self._ret_type
 
-        if ret_type not in (float, datetime.datetime):
+        if not issubclass(ret_type, (float, datetime.datetime)):
             raise TypeError("Invalid ret_type, only 'float' or 'datetime' "
                             "is acceptable.")
 
@@ -235,7 +235,7 @@ class croniter(object):
             result = self._calc(self.cur, expanded, is_prev)
         self.cur = result
 
-        if ret_type == datetime.datetime:
+        if issubclass(ret_type, datetime.datetime):
             result = self._timestamp_to_datetime(result)
 
         return result


### PR DESCRIPTION
It makes life with mocked datetime a bit easier as one can mock imported datetime and create a class derived from datetime.datetime, but can't mock datetime itself as it's C library.

Examples of alike FakeDatetime may be found [here](https://github.com/apache/incubator-airflow/blob/master/tests/ti_deps/deps/runnable_exec_date_dep.py).
