### PR TITLE
Flake8 Compliance and Test

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,3 +5,4 @@ tox>=2.4.1
 coverage>=4.2
 mock>=2.0.0  # For Python 2
 coveralls
+flake8

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -63,7 +63,8 @@ class croniter(object):
     bad_length = 'Exactly 5 or 6 columns has to be specified for iterator' \
                  'expression.'
 
-    def __init__(self, expr_format, start_time=None, ret_type=float, day_or=True):
+    def __init__(self, expr_format, start_time=None, ret_type=float,
+                 day_or=True):
         self._ret_type = ret_type
         self._day_or = day_or
 
@@ -120,19 +121,20 @@ class croniter(object):
                     low, high, step = map(int, [low, high, step])
                     e_list += range(low, high + 1, step)
                     # other solution
-                    #try:
+                    # try:
                     #    for j in xrange(int(low), int(high) + 1):
                     #        if j % int(step) == 0:
                     #            e_list.append(j)
-                    #except NameError:
+                    # except NameError:
                     #    for j in range(int(low), int(high) + 1):
                     #        if j % int(step) == 0:
                     #            e_list.append(j)
                 else:
                     if t.startswith('-'):
                         raise CroniterBadCronError(
-                            "[{0}] is not acceptable, negative numbers not allowed".format(
-                                expr_format))
+                            "[{0}] is not acceptable,\
+                            negative numbers not allowed".format(
+                                        expr_format))
                     if not star_or_int_re.search(t):
                         t = self._alphaconv(i, t)
 
@@ -275,7 +277,7 @@ class croniter(object):
         offset = len(expanded) == 6 and 1 or 60
         dst = now = self._timestamp_to_datetime(now + sign * offset)
 
-        day, month, year = dst.day, dst.month, dst.year
+        month, year = dst.month, dst.year
         current_year = now.year
         DAYS = self.DAYS
 
@@ -306,7 +308,7 @@ class croniter(object):
                 days = DAYS[month - 1]
                 if month == 2 and self.is_leap(year) is True:
                     days += 1
-                if 'l' in expanded[2] and days==d.day:
+                if 'l' in expanded[2] and days == d.day:
                     return False, d
 
                 if is_prev:
@@ -387,7 +389,7 @@ class croniter(object):
             for proc in procs:
                 (changed, dst) = proc(dst)
                 if changed:
-                    day, month, year = dst.day, dst.month, dst.year
+                    month, year = dst.month, dst.year
                     next = True
                     break
             if next:
@@ -433,9 +435,11 @@ class croniter(object):
         candidate = candidates[0]
         for c in candidates:
             # fixed: c < range_val
-            # this code will reject all 31 day of month, 12 month, 59 second, 23 hour and so on.
+            # this code will reject all 31 day of month, 12 month, 59 second,
+            # 23 hour and so on.
             # if candidates has just a element, this will not harmful.
-            # but candidates have multiple elements, then values equal to range_val will rejected.
+            # but candidates have multiple elements, then values equal to
+            # range_val will rejected.
             if c <= range_val:
                 candidate = c
                 break

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,8 @@ setenv =
     COVERAGE_FILE={envdir}/coverage_report
 changedir = src
 commands =
-    {py26,py27,py34,py35}-std: py.test -v .
-
+    {py26,py27,py34,py35,py36}-std: py.test -v .
+    {py27,py34,py35,py36}-std: flake8 src/croniter/croniter.py
     py27-coverage: coverage erase
     py27-coverage: sh -c 'cd .. && coverage run $(which py.test) -v src'
     py27-coverage: coverage report


### PR DESCRIPTION
Not sure if you guys are concerned with flake8 tests and such, but I thought I would throw a PR your way anyway. Hopefully it's something of use.

I've tested the Tox updates, which introduce flake8, against Python `2.7.13`, `3.4.6`, `3.5.3`, and `3.6.1`.

Flake8 highlighted some unused variables, which I removed, so please take care to review those specific changes.