### PR TITLE
Don't count previous minute if now is dynamic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /build
 /venv
 /.cache
+.idea

--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -227,7 +227,7 @@ class croniter(object):
             nearest_diff_method = self._get_next_nearest_diff
             sign = 1
 
-        offset = len(expanded) == 6 and 1 or 60
+        offset = (len(expanded) == 6 or now % 60 > 0) and 1 or 60
         dst = now = self._timestamp_to_datetime(now + sign * offset)
 
         month, year = dst.month, dst.year

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -790,5 +790,12 @@ class CroniterTest(base.TestCase):
         self.assertFalse(croniter.is_valid('0 * *'))
         self.assertFalse(croniter.is_valid('* * * janu-jun *'))
 
+    def test_exactly_the_same_minute(self):
+        base = datetime(2018, 3, 5, 12, 30, 50)
+        itr = croniter('30 7,12,17 * * *', base)
+        n1 = itr.get_prev(datetime)
+        self.assertEqual(12, n1.hour)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
If the code is triggered from 5-asterisk based cron `get_prev` based on `datetime.now()` is expected to return current cron iteration and not previous execution.