### PR TITLE
Fix "get_next" after exact minute change

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -223,11 +223,12 @@ class croniter(object):
         if is_prev:
             nearest_diff_method = self._get_prev_nearest_diff
             sign = -1
+            offset = (len(expanded) == 6 or now % 60 > 0) and 1 or 60
         else:
             nearest_diff_method = self._get_next_nearest_diff
             sign = 1
+            offset = (len(expanded) == 6) and 1 or 60
 
-        offset = (len(expanded) == 6 or now % 60 > 0) and 1 or 60
         dst = now = self._timestamp_to_datetime(now + sign * offset)
 
         month, year = dst.month, dst.year

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -796,6 +796,22 @@ class CroniterTest(base.TestCase):
         n1 = itr.get_prev(datetime)
         self.assertEqual(12, n1.hour)
 
+        n2 = itr.get_prev(datetime)
+        self.assertEqual(7, n2.hour)
+
+        n3 = itr.get_next(datetime)
+        self.assertEqual(12, n3.hour)
+
+    def test_next_when_now_satisfies_cron(self):
+        ts_a = datetime(2018, 5, 21, 0, 3, 0)
+        ts_b = datetime(2018, 5, 21, 0, 4, 20)
+        test_cron = '4 * * * *'
+
+        next_a = croniter(test_cron, start_time=ts_a).get_next()
+        next_b = croniter(test_cron, start_time=ts_b).get_next()
+
+        self.assertTrue(next_b > next_a)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Since [#100](https://github.com/taichino/croniter/pull/100/files), in 5-asterisk based cron, when `now` agrees with the cron string, `get_next()` is returning  it (`now`). This is not expected ([here](https://github.com/taichino/croniter/issues/102) and [here](https://github.com/rq/rq-scheduler/issues/189)).
This fix should allow backward compatibility while keeping the change in [#100](https://github.com/taichino/croniter/pull/100/files)