### PR TITLE
Fix get_next() when start_time less then 1s before next instant

### DIFF
--- a/src/croniter/croniter.py
+++ b/src/croniter/croniter.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
+
+import math
 import re
 from time import time
 import datetime
@@ -80,9 +82,6 @@ class croniter(object):
         self.tzinfo = None
         if isinstance(start_time, datetime.datetime):
             self.tzinfo = start_time.tzinfo
-            # milliseconds/microseconds rounds
-            if start_time.microsecond:
-                start_time = start_time + relativedelta(seconds=1)
             start_time = self._datetime_to_timestamp(start_time)
 
         self.start_time = start_time
@@ -224,10 +223,12 @@ class croniter(object):
 
     def _calc(self, now, expanded, nth_weekday_of_month, is_prev):
         if is_prev:
+            now = math.ceil(now)
             nearest_diff_method = self._get_prev_nearest_diff
             sign = -1
             offset = (len(expanded) == 6 or now % 60 > 0) and 1 or 60
         else:
+            now = math.floor(now)
             nearest_diff_method = self._get_next_nearest_diff
             sign = 1
             offset = (len(expanded) == 6) and 1 or 60

--- a/src/croniter/tests/test_croniter.py
+++ b/src/croniter/tests/test_croniter.py
@@ -3,6 +3,7 @@
 
 import unittest
 from datetime import datetime, timedelta
+from functools import partial
 from time import sleep
 import pytz
 from croniter import croniter, CroniterBadDateError, CroniterBadCronError, CroniterNotAlphaError
@@ -816,21 +817,38 @@ class CroniterTest(base.TestCase):
         """
         https://github.com/taichino/croniter/issues/107
         """
-        #
+
+        _croniter = partial(croniter, "0 10 * * *", ret_type=datetime)
+
         dt = datetime(2018, 1, 2, 10, 0, 0, 500)
-        c = croniter("0 10 * * * ", start_time=dt)
-        ts = "{0}".format(datetime.utcfromtimestamp(c.get_prev()))
-        self.assertEqual(ts, '2018-01-02 10:00:00')
-        #
+        self.assertEqual(
+            _croniter(start_time=dt).get_prev(),
+            datetime(2018, 1, 2, 10, 0),
+        )
+        self.assertEqual(
+            _croniter(start_time=dt).get_next(),
+            datetime(2018, 1, 3, 10, 0),
+        )
+
         dt = datetime(2018, 1, 2, 10, 0, 1, 0)
-        c = croniter("0 10 * * * ", start_time=dt)
-        ts = "{0}".format(datetime.utcfromtimestamp(c.get_prev()))
-        self.assertEqual(ts, '2018-01-02 10:00:00')
-        #
+        self.assertEqual(
+            _croniter(start_time=dt).get_prev(),
+            datetime(2018, 1, 2, 10, 0),
+        )
+        self.assertEqual(
+            _croniter(start_time=dt).get_next(),
+            datetime(2018, 1, 3, 10, 0),
+        )
+
         dt = datetime(2018, 1, 2, 9, 59, 59, 999999)
-        c = croniter("0 10 * * * ", start_time=dt)
-        ts = "{0}".format(datetime.utcfromtimestamp(c.get_prev()))
-        self.assertEqual(ts, '2018-01-01 10:00:00')
+        self.assertEqual(
+            _croniter(start_time=dt).get_prev(),
+            datetime(2018, 1, 1, 10, 0),
+        )
+        self.assertEqual(
+            _croniter(start_time=dt).get_next(),
+            datetime(2018, 1, 2, 10, 0),
+        )
 
     def test_invalid_zerorepeat(self):
         self.assertFalse(croniter.is_valid('*/0 * * * *'))
@@ -845,7 +863,7 @@ class CroniterTest(base.TestCase):
             ret.append(dt)
             dt += timedelta(days=1)
         sret = ["{0}".format(r) for r in ret]
-        self.assertEquals(
+        self.assertEqual(
             sret,
             ['2019-01-15 00:00:00',
              '2019-01-16 00:00:01',
@@ -865,7 +883,7 @@ class CroniterTest(base.TestCase):
             ret.append(dt)
             dt += timedelta(days=1)
         sret = ["{0}".format(r) for r in ret]
-        self.assertEquals(
+        self.assertEqual(
             sret,
             ['2019-01-14 00:00:01',
              '2019-01-15 00:00:02',
@@ -888,7 +906,7 @@ class CroniterTest(base.TestCase):
             ret.append(dt)
             dt += timedelta(days=1)
         sret = ["{0}".format(r) for r in ret]
-        self.assertEquals(
+        self.assertEqual(
             sret,
             ['2019-01-16 00:00:00',
              '2019-01-17 00:00:01',


### PR DESCRIPTION
```python
import croniter
from datetime import datetime
i = croniter.croniter('1 * * * *', datetime(2020, 1, 1, 10, 0, 59, 500000), ret_type=datetime)
i.get_next()
datetime.datetime(2020, 1, 1, 11, 1)
```

`start_time` is 0.5s before 10:01am, which should be the next instant returned. However, croniter skips ahead to the next instance at 11:01am.

This bug occurs when the `start_time` is less than one second before the true next iteration. It was introduced by af9e41a3293f4cf8bb7ec8b3ec9298fac735d967, which pushes the start time back by one second if there is any sub-second component.

The fix is to round the time up or down to the nearest second depending on whether we're getting the previous or next value in `_calc`.