### PR TITLE
feat: support Python 3.6, 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: python
 python:
+#  - 2.6
   - 2.7
   - 3.4
   - 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
   - 2.7
   - 3.4
   - 3.5
+  - 3.6
+  - 3.7
 install:
     - pip install -r requirements/test.txt
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: python
 python:
-#  - 2.6
   - 2.7
   - 3.4
   - 3.5

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,8 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Software Development :: Libraries :: Python Modules"],
     packages=find_packages('src'),
     package_dir={'': 'src'},

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     keywords='datetime, iterator, cron',
     install_requires=install_requires,
     license="MIT License",
-    python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
@@ -44,7 +44,6 @@ setup(
         "Operating System :: POSIX",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     keywords='datetime, iterator, cron',
     install_requires=install_requires,
     license="MIT License",
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
@@ -44,6 +44,7 @@ setup(
         "Operating System :: POSIX",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 2.3
 envlist =
-    {py27,py34,py35}-std
+    {py27,py34,py35,py36,py37}-std
     py27-coverage
 skipsdist = true
 
@@ -14,9 +14,8 @@ setenv =
     COVERAGE_FILE={envdir}/coverage_report
 changedir = src
 commands =
-    {py27,py34,py35,py36}-std: py.test -v .
-    {py27,py34,py35,py36}-std: flake8 src/croniter/croniter.py
+    {py27,py34,py35,py36,py37}-std: py.test -v .
+    {py27,py34,py35,py36,py37}-std: flake8 src/croniter/croniter.py
     py27-coverage: coverage erase
     py27-coverage: sh -c 'cd .. && coverage run $(which py.test) -v src'
     py27-coverage: coverage report
-

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 2.3
 envlist =
-    {py26,py27,py34,py35}-std
+    {py27,py34,py35}-std
     py27-coverage
 skipsdist = true
 
@@ -14,7 +14,7 @@ setenv =
     COVERAGE_FILE={envdir}/coverage_report
 changedir = src
 commands =
-    {py26,py27,py34,py35,py36}-std: py.test -v .
+    {py27,py34,py35,py36}-std: py.test -v .
     {py27,py34,py35,py36}-std: flake8 src/croniter/croniter.py
     py27-coverage: coverage erase
     py27-coverage: sh -c 'cd .. && coverage run $(which py.test) -v src'

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 2.3
 envlist =
-    {py27,py34,py35,py36,py37}-std
+    {py26,py27,py34,py35,py36,py37}-std
     py27-coverage
 skipsdist = true
 
@@ -14,7 +14,7 @@ setenv =
     COVERAGE_FILE={envdir}/coverage_report
 changedir = src
 commands =
-    {py27,py34,py35,py36,py37}-std: py.test -v .
+    {py26,py27,py34,py35,py36,py37}-std: py.test -v .
     {py27,py34,py35,py36,py37}-std: flake8 src/croniter/croniter.py
     py27-coverage: coverage erase
     py27-coverage: sh -c 'cd .. && coverage run $(which py.test) -v src'


### PR DESCRIPTION
Hi! Thanks for writing croniter, we use it over at https://github.com/getsentry/sentry.

Just wanted to make sure tests pass on 3.6 + 3.7. Looks like it just works, at least in a local py37 venv. I've updated your CI config and some metadata for 2.7 and 3.4-7.