### PR TITLE
Add Python 3.8 and 3.9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   - 3.6
   - 3.7
   - 3.8
+  - 3.9
 install:
     - pip install -r requirements/test.txt
 script:

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 0.3.37 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Added Python 3.8 and 3.9 support
+  [eumiro]
 
 
 0.3.36 (2020-11-02)

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,8 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Software Development :: Libraries :: Python Modules"],
     packages=find_packages('src', exclude=['tests*', '*.tests*']),
     package_dir={'': 'src'},

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 2.3
 envlist =
-    {py26,py27,py34,py35,py36,py37}-std
+    {py26,py27,py34,py35,py36,py37,py38,py39}-std
     py27-coverage
 skipsdist = true
 
@@ -14,8 +14,8 @@ setenv =
     COVERAGE_FILE={envdir}/coverage_report
 changedir = src
 commands =
-    {py26,py27,py34,py35,py36,py37}-std: py.test -v .
-    {py27,py34,py35,py36,py37}-std: flake8 croniter/croniter.py
+    {py26,py27,py34,py35,py36,py37,py38,py39}-std: py.test -v .
+    {py27,py34,py35,py36,py37,py38,py39}-std: flake8 croniter/croniter.py
     py27-coverage: coverage erase
     py27-coverage: sh -c 'cd .. && coverage run $(which py.test) -v src'
     py27-coverage: coverage report


### PR DESCRIPTION
Add Python 3.8 and 3.9 everywhere.

Would you consider dropping support for Python older than 3.6? All of them are after EOL.