### PR TITLE
fix missing encoding parameter in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 def read(*rnames):
     return open(
-        os.path.join('.', *rnames)
+        os.path.join('.', *rnames), encoding="utf-8"
     ).read()
 
 install_requires = [


### PR DESCRIPTION
This fixes setup.py on Windows (see log below).

Reference : https://www.python.org/dev/peps/pep-0597/#using-the-default-encoding-is-a-common-mistake

```
PS C:\Somewhere\croniter> pip install -e .
Obtaining file:///C:/Somewhere/croniter
    ERROR: Command errored out with exit status 1:
     command: 'c:\somewhere\appdata\local\programs\python\python38\python.exe' -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'C:\\Users\\Olivier\\Code\\croniter\\setup.py'"'"'; __file__='"'"'C:\\Users\\Olivier\\Code\\croniter\\setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base 'C:\Somewhere\AppData\Local\Temp\pip-pip-egg-info-_hgf5n4g'
    Complete output (9 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Somewhere\croniter\setup.py", line 20, in <module>
        read('docs', 'CHANGES.rst'),
      File "C:\Somewhere\croniter\setup.py", line 7, in read
        return open(
      File "c:\somewhere\appdata\local\programs\python\python38\lib\encodings\cp1252.py", line 23, in decode
        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
    UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 4671: character maps to <undefined>
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```